### PR TITLE
Recommender API integration:

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -2,6 +2,7 @@ PORT=3000
 EMBEDDINGS_API=http://localhost:8000
 PATHWAY_API=https://api.pathway.md/v8/chat/completions
 PATHWAY_MODEL=pathway-v8-0
+RECOMMENDER_API=http://localhost:8888
 SESSION_SECRET=session-secret
 CORS_ORIGINS=https://frontend.com,https://another-frontend.com
 

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -4,9 +4,15 @@ import { Module } from '@nestjs/common';
 import { ConfigModule } from '@nestjs/config';
 import { TemplateSelectorModule } from './template-selector/template-selector.module';
 import { PathwayModule } from './pathway/pathway.module';
+import { RecommenderModule } from './recommender/recommender.module';
 
 @Module({
-  imports: [ConfigModule.forRoot(), TemplateSelectorModule, PathwayModule],
+  imports: [
+    ConfigModule.forRoot(),
+    TemplateSelectorModule,
+    PathwayModule,
+    RecommenderModule,
+  ],
   controllers: [AppController],
   providers: [AppService],
 })

--- a/src/models/referralResponse.ts
+++ b/src/models/referralResponse.ts
@@ -1,6 +1,7 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { SpecialistAIResponse } from './specialistAIResponse';
 import { LLMResponse } from './llmResponse';
+import { GetOrdersResponse } from '../recommender/models/getOrdersResponse';
 
 // {
 //   "specialistSummary": string,
@@ -11,4 +12,7 @@ import { LLMResponse } from './llmResponse';
 export class ReferralResponse extends LLMResponse {
   @ApiProperty({ description: 'Specialist AI response' })
   specialistAIResponse?: SpecialistAIResponse;
+
+  @ApiProperty({ description: 'Recommender API response' })
+  recommenderResponse?: GetOrdersResponse;
 }

--- a/src/recommender/models/clinicalCaseRequest.ts
+++ b/src/recommender/models/clinicalCaseRequest.ts
@@ -1,0 +1,13 @@
+import { Expose } from 'class-transformer';
+
+export class ClinicalCaseRequest {
+  @Expose({ name: 'clinical_question' })
+  public clinicalQuestion: string;
+  @Expose({ name: 'clinical_notes' })
+  public clinicalNotes: string;
+
+  constructor(clinicalQuestion: string, clinicalNotes: string) {
+    this.clinicalQuestion = clinicalQuestion;
+    this.clinicalNotes = clinicalNotes;
+  }
+}

--- a/src/recommender/models/clinicalCaseResponse.ts
+++ b/src/recommender/models/clinicalCaseResponse.ts
@@ -1,0 +1,18 @@
+import { Expose } from 'class-transformer';
+
+export class ClinicalCaseResponse {
+  @Expose({ name: 'patient_age' })
+  patientAge: number;
+  @Expose({ name: 'patient_gender' })
+  patientGender: string;
+  @Expose({ name: 'icd10_code' })
+  icd10Code: string;
+  @Expose({ name: 'rationale' })
+  rationale: number;
+  @Expose({ name: 'error' })
+  error: any;
+  @Expose({ name: 'retry_count' })
+  retryCount: number;
+  @Expose({ name: 'stopped' })
+  stopped: boolean;
+}

--- a/src/recommender/models/getOrdersRequest.ts
+++ b/src/recommender/models/getOrdersRequest.ts
@@ -1,0 +1,28 @@
+import { Expose } from 'class-transformer';
+import { ClinicalCaseResponse } from './clinicalCaseResponse';
+
+export class GetOrdersRequest {
+  @Expose({ name: 'patient_age' })
+  patientAge: number;
+  @Expose({ name: 'patient_gender' })
+  patientGender: string;
+  @Expose({ name: 'icd10_code' })
+  icd10Code: string;
+  limit: number = 10; // TODO make this configurable
+
+  constructor(patientAge: number, patientGender: string, icd10Code: string) {
+    this.patientAge = patientAge;
+    this.patientGender = patientGender;
+    this.icd10Code = icd10Code;
+  }
+
+  public static fromClinicalCaseResponse(
+    clinicalCaseResponse: ClinicalCaseResponse,
+  ): GetOrdersRequest {
+    return new GetOrdersRequest(
+      clinicalCaseResponse.patientAge,
+      clinicalCaseResponse.patientGender,
+      clinicalCaseResponse.icd10Code,
+    );
+  }
+}

--- a/src/recommender/models/getOrdersResponse.ts
+++ b/src/recommender/models/getOrdersResponse.ts
@@ -1,0 +1,46 @@
+import { Expose } from 'class-transformer';
+import { ApiProperty } from '@nestjs/swagger';
+
+export class Order {
+  @ApiProperty({ description: 'Order item ID' })
+  itemId: string;
+  @ApiProperty({ description: 'Order description' })
+  description: string;
+  @ApiProperty({
+    description: 'Percentage of patients for which this order was made',
+  })
+  patientRate: number;
+  @ApiProperty({ description: 'TODO' })
+  encounterRate: number;
+  @ApiProperty({ description: 'TODO' })
+  nPatientscohortItem: number;
+  @ApiProperty({ description: 'TODO' })
+  nEncounterscohortItem: number;
+  @ApiProperty({ description: 'TODO' })
+  nPatientsCohortTotal: number;
+  @ApiProperty({ description: 'TODO' })
+  nEncountersCohortTotal: number;
+  @ApiProperty({
+    description: 'Order type, can be "procedure", "med" or "lab"',
+  })
+  result_type: string;
+}
+
+export class GetOrdersResponse {
+  @ApiProperty({ description: 'ICD10 diagnosis code' })
+  @Expose({ name: 'icd10_code' })
+  icd10Code: string;
+  @ApiProperty({
+    description: 'TODO',
+  })
+  @Expose({ name: 'result_type' })
+  resultType: string;
+  @ApiProperty({ description: 'Patient age' })
+  @Expose({ name: 'patient_age' })
+  patientAge: number;
+  @ApiProperty({ description: 'Patient gender' })
+  @Expose({ name: 'patient_gender' })
+  patientGender: string;
+  @ApiProperty({ description: 'Orders', type: [Order] })
+  data: Order[];
+}

--- a/src/recommender/recommender.module.ts
+++ b/src/recommender/recommender.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { RecommenderService } from './recommender.service';
+import { HttpModule } from '@nestjs/axios';
+
+@Module({
+  imports: [HttpModule],
+  providers: [RecommenderService],
+  exports: [RecommenderService],
+})
+export class RecommenderModule {}

--- a/src/recommender/recommender.service.spec.ts
+++ b/src/recommender/recommender.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { RecommenderService } from './recommender.service';
+
+describe('RecommenderService', () => {
+  let service: RecommenderService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [RecommenderService],
+    }).compile();
+
+    service = module.get<RecommenderService>(RecommenderService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/src/recommender/recommender.service.ts
+++ b/src/recommender/recommender.service.ts
@@ -1,0 +1,120 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { HttpService } from '@nestjs/axios';
+import { ClinicalCaseRequest } from './models/clinicalCaseRequest';
+import { catchError, lastValueFrom, map, throwError } from 'rxjs';
+import { instanceToInstance, plainToInstance } from 'class-transformer';
+import { ClinicalCaseResponse } from './models/clinicalCaseResponse';
+import { AxiosError } from 'axios';
+import { GetOrdersResponse } from './models/getOrdersResponse';
+import { GetOrdersRequest } from './models/getOrdersRequest';
+
+const RecommenderPaths = {
+  processClinicalCasePath: '/process_clinical_case',
+  getOrdersPath: '/get_orders',
+} as const;
+
+@Injectable()
+export class RecommenderService {
+  private readonly logger: Logger = new Logger(RecommenderService.name);
+
+  constructor(private readonly httpService: HttpService) {}
+
+  async retrieveRecommendations(
+    clinicalQuestion: string,
+    clinicalNotes: string,
+  ): Promise<GetOrdersResponse> {
+    const request: ClinicalCaseRequest = this.prepareRequest(
+      clinicalQuestion,
+      clinicalNotes,
+    );
+
+    try {
+      const clinicalCase: ClinicalCaseResponse =
+        await this.retrieveClinicalCaseResponse(instanceToInstance(request));
+
+      return lastValueFrom(
+        this.httpService
+          .post<GetOrdersResponse, GetOrdersRequest>(
+            String(process.env.RECOMMENDER_API) +
+              RecommenderPaths.getOrdersPath,
+            instanceToInstance(
+              GetOrdersRequest.fromClinicalCaseResponse(clinicalCase),
+            ),
+          )
+          .pipe(
+            catchError((error: AxiosError) => {
+              // in case of an error just return the empty response
+              this.logger.error(
+                'error querying Recommender Get Orders API',
+                error.response?.data,
+                request,
+              );
+              return throwError(
+                () =>
+                  new Error(
+                    'Error querying Recommender Get Orders API: ' +
+                      error.message,
+                  ),
+              );
+            }),
+          )
+          .pipe(
+            // looks like we need to manually map the data to the type we want via class-transform
+            map((response) => {
+              response.data = plainToInstance(GetOrdersResponse, response.data);
+              return response.data;
+            }),
+          ),
+      );
+    } catch (e) {
+      return Promise.reject(e as Error);
+    }
+  }
+
+  private retrieveClinicalCaseResponse(
+    request: ClinicalCaseRequest,
+  ): Promise<ClinicalCaseResponse> {
+    return lastValueFrom(
+      this.httpService
+        .post<ClinicalCaseResponse, ClinicalCaseRequest>(
+          String(process.env.RECOMMENDER_API) +
+            RecommenderPaths.processClinicalCasePath,
+          request,
+        )
+        .pipe(
+          catchError((error: AxiosError) => {
+            // in case of an error just return the empty response
+            this.logger.error(
+              'error querying Recommender Process Clinical Case API',
+              error.response?.data,
+              request,
+            );
+            return throwError(
+              () =>
+                new Error(
+                  'Error querying Recommender Process Clinical Case API: ' +
+                    error.message,
+                ),
+            );
+          }),
+        )
+        .pipe(
+          // looks like we need to manually map the data to the type we want via class-transform
+          map((response) => {
+            response.data = plainToInstance(
+              ClinicalCaseResponse,
+              response.data,
+            );
+            return response.data;
+          }),
+        ),
+    );
+  }
+
+  private prepareRequest(
+    clinicalQuestion: string,
+    clinicalNotes: string,
+  ): ClinicalCaseRequest {
+    return new ClinicalCaseRequest(clinicalQuestion, clinicalNotes);
+  }
+}


### PR DESCRIPTION
- on the non-streamed endpoint - recommender responses is awaited after Pathway response
- on the streamed endpoint - it is parallel to Pathway response.
- TODO need clarification of some Recommender orders fields
- TODO might need to handle Recommender API errors better
- added limit of 10 orders per order type.